### PR TITLE
Fix CentOS/RHEL 7.5 install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6"
     ],
     install_requires=[
-        'requests ~= 2.18.4',
+        'requests >= 2.18.4',
         'python-dateutil',
         'pytz'
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="rubrik_cdm",
-    version="1.0.6",
+    version="1.0.7",
     author="Rubrik Ranger Team",
     description="A Python package for interacting with the Rubrik CDM API.",
     long_description=long_description,


### PR DESCRIPTION
Update the pip install requirements to support older versions of setup tools.